### PR TITLE
Allow aspera to modify the config object

### DIFF
--- a/src/react-aspera-connect.js
+++ b/src/react-aspera-connect.js
@@ -4,10 +4,10 @@ export let asperaWeb, asperaInstaller, config;
 export const initAspera = (params) => {
   const { AW4 } = window;
 
-  config = Object.freeze({
+  config = {
     ...params,
     minVersion: params.minVersion || '3.8.0'
-  });
+  };
   
   asperaWeb = new AW4.Connect({ sdkLocation: config.sdkLocation, minVersion: config.minVersion });
   asperaInstaller = new AW4.ConnectInstaller({ sdkLocation: config.sdkLocation });


### PR DESCRIPTION
AW4.Connect() fails if the config is frozen, as it prevents it adding a property to it.

This wasn't an issue previously, so looks like a change to AW4.Connect()